### PR TITLE
Do not constrain on max python 3.12 and add scripts entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pillow~=11.0.0"
 ]
 optional-dependencies.full = ["python-barcode[images]~=0.15.1"]
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.10"
 
 [project.urls]
 "GitHub" = "https://github.com/ysfchn/dymo-bluetooth"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ requires-python = ">=3.10"
 [project.urls]
 "GitHub" = "https://github.com/ysfchn/dymo-bluetooth"
 
+[project.scripts]
+dymo_bluetooth = "dymo_bluetooth.__main__:main"
+
 [tool.setuptools]
 packages = ["dymo_bluetooth"]
 


### PR DESCRIPTION
Hi! thank's for your work! I am trying to run it in arch linux with pipx and It tells me that:

`ERROR: Package 'dymo-bluetooth' requires a different Python: 3.13.1 not in '<3.12,>=3.10'`

Does it need to be constrained to this max version(3.12)?

Also, when trying to install with pipx forcing the python version:

```
pipx install --fetch-missing-python  --python 3.11 https://github.com/ysfchn/dymo-bluetooth/archive/refs/heads/main.zip

No apps associated with package dymo-bluetooth or its dependencies. If you are attempting to install a library, pipx should not be used. Consider using pip or a similar tool instead.
```

After looking here and there, it seems that adding `project.scripts` could let it be installed.

