### PR TITLE
Add another possible mac range

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This printer uses Bluetooth LE (GATT) to send labels & retrieve its status. It d
 
 `2b3d` part in the UUID may not be future-proof, but so far all produced printers of the same model seems to share the same UUID.
 
-To discover the nearby printers, filter for the service UUID or/and check for the MAC address range. This printer has a MAC address in range of `58:CF:79:00:00:00` and `58:CF:79:FF:FF:FF`, which this MAC range block seems to be owned by Espressif Inc. according to Bluetooth vendor list.
+To discover the nearby printers, filter for the service UUID or/and check for the MAC address range. This printer has a MAC address in range of `58:CF:79:00:00:00` and `58:CF:79:FF:FF:FF` or `DC:54:75:00:00:00` and `DC:54:75:FF:FF:FF`, which these MAC ranges block seems to be owned by Espressif Inc. according to Bluetooth vendor list.
 
 All data structures are explained below so it can be used as a future reference.
 

--- a/dymo_bluetooth/bluetooth.py
+++ b/dymo_bluetooth/bluetooth.py
@@ -50,6 +50,11 @@ def is_espressif(mac : str):
     mac_value = int(mac.replace(":", ""), base = 16)
     if (mac_value >= start_block) and (mac_value < end_block):
         return True
+    start_block = 0xDC_54_75 << 24
+    end_block = start_block + (1 << 24) # Exclusive
+    mac_value = int(mac.replace(":", ""), base = 16)
+    if (mac_value >= start_block) and (mac_value < end_block):
+        return True
     return False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pillow~=11.0.0"
 ]
 optional-dependencies.full = ["python-barcode[images]~=0.15.1"]
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.10"
 
 [project.urls]
 "GitHub" = "https://github.com/ysfchn/dymo-bluetooth"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ requires-python = ">=3.10"
 [project.urls]
 "GitHub" = "https://github.com/ysfchn/dymo-bluetooth"
 
+[project.scripts]
+dymo_bluetooth = "dymo_bluetooth.__main__:main"
+
 [tool.setuptools]
 packages = ["dymo_bluetooth"]
 


### PR DESCRIPTION
My Letratag has another mac address that starts with DC:54:75 , it seems that is also owned by Espressif inc. as of: https://maclookup.app/macaddress/DC5475 . So make it also available. 