### PR TITLE
Cross-platform directory separator usage

### DIFF
--- a/dymo_bluetooth/__main__.py
+++ b/dymo_bluetooth/__main__.py
@@ -26,6 +26,7 @@ from typing import cast
 from dymo_bluetooth.bluetooth import discover_printers, create_image
 import sys
 import asyncio
+import os
 
 async def print_image(
     input_file : Path, 
@@ -46,7 +47,7 @@ async def print_image(
 
 
 def main():
-    module_name = cast(str, sys.modules[__name__].__file__).split("/")[-2]
+    module_name = cast(str, sys.modules[__name__].__file__).split(os.sep)[-2]
     args = ArgumentParser(
         prog = f"python -m {module_name}",
         description = (


### PR DESCRIPTION
Script is failing on Windows due to a hard-coded slash used as directory separator.

This PR fixes that by using `os.sep` to get the separator.